### PR TITLE
Shorten test runs by running only a subset of RBNF tests by default 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.2.0
-script: 'bundle exec rake'
+script: 'bundle exec rake spec:js:full'

--- a/Rakefile
+++ b/Rakefile
@@ -30,7 +30,17 @@ RSpec::Core::RakeTask.new("spec:ruby") do |t|
 end
 
 desc 'Run JavaScript specs'
+
 task "spec:js" do
+  run_tests()
+end
+
+task "spec:js:full" do
+  ENV["FULL_TEST_SUITE"] = "True"
+  run_tests()
+end
+
+def run_tests
   ENV["LOCALES"] = "en,ar,ko,ru,hi"
   Rake::Task["twitter_cldr:js:update_for_test"].invoke
 

--- a/spec/js/numbers/rbnf.spec.js
+++ b/spec/js/numbers/rbnf.spec.js
@@ -35,7 +35,7 @@ function rbnf_test_case (locale, rule_group, rule_set, test_case) {
       }
       catch (error) {
         if (!(error instanceof TwitterCldr.NotImplementedException)) {
-            throw error;
+          throw error;
         }
       }
     });
@@ -43,13 +43,15 @@ function rbnf_test_case (locale, rule_group, rule_set, test_case) {
 }
 
 for (var locale in TwitterCldr.RBNF.test_resource) {
-
   if (["ar", "ja", "ko", "zh", "ja", "zh-Hant", "ja", "hi", "ta"].indexOf(locale) !== -1)
     continue;
   for (var rule_group in TwitterCldr.RBNF.test_resource[locale]) {
     if (formatter.group_names().indexOf(rule_group) === -1)
       continue;
     for (var rule_set in TwitterCldr.RBNF.test_resource[locale][rule_group]) {
+      if (!process.env.FULL_TEST_SUITE && rule_set !== 'spellout-numbering') {
+        continue;
+      }
       if (formatter.rule_set_names_for_group(rule_group).indexOf(rule_set) === -1)
         continue;
       for (var test_case in TwitterCldr.RBNF.test_resource[locale][rule_group][rule_set]) {


### PR DESCRIPTION
- Only `spellout-numbering` tests are run by default
- The whole suite can be run by using the `spec:js:full` task
- The whole suite runs on travis

Otherwise the tests take too long because there are about 30k of them(!)

@camertron @KL-7 
